### PR TITLE
build_less_targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,33 @@ endif ()
 
 project(dEQP-Core-${DEQP_TARGET})
 
+if (EMSCRIPTEN)
+	# TODO: Currently does not build when setting EGL OFF with Emscripten, but
+	# add support for this.
+	set(EGL_DEFAULT ON)
+	set(GLES3_DEFAULT OFF)
+	set(VULKAN_DEFAULT OFF)
+else()
+	set(EGL_DEFAULT ON)
+	set(GLES3_DEFAULT ON)
+	set(VULKAN_DEFAULT ON)
+endif ()
+
+option(VULKAN "Build tests that target Vulkan" ${VULKAN_DEFAULT})
+message(STATUS "Targeting Vulkan tests module: ${VULKAN}")
+if (VULKAN)
+	add_definitions(-DDEQP_VULKAN)
+endif ()
+
+option(EGL "Build tests that target EGL" ${EGL_DEFAULT})
+message(STATUS "Targeting EGL tests module: ${EGL}")
+if (EGL)
+	add_definitions(-DDEQP_EGL)
+endif ()
+
+option(GLES3 "Build tests that target OpenGL ES 3.0" ${GLES3_DEFAULT})
+message(STATUS "Targeting OpenGL ES 3.0 tests module: ${GLES3}")
+
 include(framework/delibs/cmake/Defs.cmake NO_POLICY_SCOPE)
 include(framework/delibs/cmake/CFlags.cmake)
 
@@ -73,12 +100,14 @@ if (NOT PNG_INCLUDE_PATH OR NOT PNG_LIBRARY)
 endif ()
 
 # glslang
-add_subdirectory(external/glslang)
+if (NOT EMSCRIPTEN)
+	add_subdirectory(external/glslang)
+endif ()
 
 # spirv-tools
 if (NOT EMSCRIPTEN)
 	add_subdirectory(external/spirv-tools)
-endif()
+endif ()
 
 include_directories(${PNG_INCLUDE_PATH})
 
@@ -157,11 +186,15 @@ add_subdirectory(framework/delibs/deutil)
 add_subdirectory(framework/delibs/decpp)
 
 # ExecServer
-add_subdirectory(execserver)
+if (NOT EMSCRIPTEN)
+	add_subdirectory(execserver)
+endif ()
 
 # Executor framework and tools
 if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/executor)
-	add_subdirectory(executor)
+	if (NOT EMSCRIPTEN)
+		add_subdirectory(executor)
+	endif ()
 endif ()
 
 # Test framework include directories
@@ -266,15 +299,21 @@ macro (add_data_file MODULE_NAME SRC_FILE DST_FILE)
 endmacro (add_data_file)
 
 add_subdirectory(framework)
-add_subdirectory(external/vulkancts/framework/vulkan)
+
+if (NOT EMSCRIPTEN)
+	add_subdirectory(external/vulkancts/framework/vulkan)
+endif ()
 
 if (DE_COMPILER_IS_MSC)
 	add_compile_options(/bigobj) # Required by glsBuiltinPrecisionTests.cpp
 endif ()
 
 add_subdirectory(modules)
-add_subdirectory(external/vulkancts/modules/vulkan)
-add_subdirectory(external/openglcts)
+
+if (NOT EMSCRIPTEN)
+	add_subdirectory(external/vulkancts/modules/vulkan)
+	add_subdirectory(external/openglcts)
+endif ()
 
 # Single-binary targets
 if (DE_OS_IS_ANDROID)

--- a/external/openglcts/modules/common/CMakeLists.txt
+++ b/external/openglcts/modules/common/CMakeLists.txt
@@ -83,8 +83,11 @@ set(GLCTS_COMMON_SRCS
 set(GLCTS_COMMON_LIBS
 	glutil
 	tcutil
-	eglutil
 	)
+
+if (EGL)
+	set(GLCTS_COMMON_LIBS "${GLCTS_COMMON_LIBS} eglutil")
+endif ()
 
 add_library(glcts-common STATIC ${GLCTS_COMMON_SRCS})
 target_link_libraries(glcts-common ${GLCTS_COMMON_LIBS})

--- a/external/openglcts/modules/common/glcConfigListEGL.cpp
+++ b/external/openglcts/modules/common/glcConfigListEGL.cpp
@@ -22,6 +22,8 @@
  * \brief CTS rendering configuration list utility.
  */ /*-------------------------------------------------------------------*/
 
+#ifdef DEQP_EGL
+
 #include "glcConfigListEGL.hpp"
 
 #include "deUniquePtr.hpp"
@@ -167,3 +169,5 @@ void getConfigListEGL(tcu::Platform& platform, glu::ApiType type, ConfigList& co
 }
 
 } // glcts
+
+#endif

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -10,7 +10,9 @@ add_subdirectory(common)
 add_subdirectory(opengl)
 
 # EGL utilities
-add_subdirectory(egl)
+if (EGL)
+	add_subdirectory(egl)
+endif ()
 
 if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/randomshaders)
 	add_subdirectory(randomshaders)

--- a/framework/platform/CMakeLists.txt
+++ b/framework/platform/CMakeLists.txt
@@ -143,15 +143,19 @@ endif ()
 add_library(tcutil-platform STATIC ${TCUTIL_PLATFORM_SRCS})
 
 # Add vkutil to the deps before tcutil so that it picks up the c++11 dependencies
-target_link_libraries(tcutil-platform vkutil)
+if (VULKAN)
+	target_link_libraries(tcutil-platform vkutil)
+endif ()
 
 target_link_libraries(tcutil-platform tcutil ${TCUTIL_PLATFORM_LIBS})
 
 # Always link to glutil as some platforms such as Win32 always support GL
 target_link_libraries(tcutil-platform glutil)
 
-# Always link to eglutil
-target_link_libraries(tcutil-platform eglutil)
+if (EGL)
+	# Always link to eglutil
+	target_link_libraries(tcutil-platform eglutil)
+endif ()
 
 # X11 libraries
 if (DEQP_USE_X11)

--- a/framework/platform/emscripten/tcuEmscriptenPlatform.cpp
+++ b/framework/platform/emscripten/tcuEmscriptenPlatform.cpp
@@ -31,6 +31,8 @@
 
 #include "emscripten.h"
 
+#ifdef DEQP_EGL
+
 tcu::Platform* createPlatform (void)
 {
 	return new tcu::emscripten::Platform();
@@ -157,3 +159,5 @@ Platform::~Platform (void)
 
 } // emscripten
 } // tcu
+
+#endif

--- a/framework/platform/emscripten/tcuEmscriptenPlatform.hpp
+++ b/framework/platform/emscripten/tcuEmscriptenPlatform.hpp
@@ -33,6 +33,8 @@ namespace tcu
 namespace emscripten
 {
 
+#ifdef DEQP_EGL
+
 class Platform : public tcu::Platform, private eglu::Platform, private glu::Platform
 {
 public:
@@ -42,6 +44,8 @@ public:
 	virtual const glu::Platform&	getGLPlatform		(void) const { return static_cast<const glu::Platform&>	(*this);	}
 	virtual const eglu::Platform&	getEGLPlatform		(void) const { return static_cast<const eglu::Platform&>(*this);	}
 };
+
+#endif
 
 } // emscripten
 } // tcu

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,9 +1,18 @@
 # dEQP Modules
 add_subdirectory(glshared)
 add_subdirectory(gles2)
-add_subdirectory(gles3)
-add_subdirectory(gles31)
-add_subdirectory(egl)
+
+if (GLES3)
+	add_subdirectory(gles3)
+endif ()
+
+if (NOT EMSCRIPTEN)
+	add_subdirectory(gles31)
+endif ()
+
+if (EGL)
+	add_subdirectory(egl)
+endif ()
 
 # Misc
 add_subdirectory(internal)

--- a/modules/internal/CMakeLists.txt
+++ b/modules/internal/CMakeLists.txt
@@ -32,8 +32,11 @@ set(DE_INTERNAL_TESTS_SRCS
 set(DE_INTERNAL_TESTS_LIBS
 	tcutil
 	referencerenderer
-	vkutil
 	)
+
+if (VULKAN)
+	set(DE_INTERNAL_TESTS_LIBS "${DE_INTERNAL_TESTS_LIBS} vkutil")
+endif ()
 
 add_deqp_module(de-internal-tests "${DE_INTERNAL_TESTS_SRCS}" "${DE_INTERNAL_TESTS_LIBS}" ditTestPackageEntry.cpp)
 

--- a/modules/internal/ditFrameworkTests.cpp
+++ b/modules/internal/ditFrameworkTests.cpp
@@ -929,7 +929,9 @@ void FrameworkTests::init (void)
 	addChild(new ReferenceRendererTests	(m_testCtx));
 	addChild(createTextureFormatTests	(m_testCtx));
 	addChild(createAstcTests			(m_testCtx));
+#ifdef DEQP_VULKAN
 	addChild(createVulkanTests			(m_testCtx));
+#endif
 }
 
 } // dit

--- a/modules/internal/ditVulkanTests.cpp
+++ b/modules/internal/ditVulkanTests.cpp
@@ -31,6 +31,8 @@
 namespace dit
 {
 
+#ifdef DEQP_VULKAN
+
 tcu::TestCaseGroup* createVulkanTests (tcu::TestContext& testCtx)
 {
 	de::MovePtr<tcu::TestCaseGroup>	group	(new tcu::TestCaseGroup(testCtx, "vulkan", "Vulkan Framework Tests"));
@@ -39,5 +41,7 @@ tcu::TestCaseGroup* createVulkanTests (tcu::TestContext& testCtx)
 
 	return group.release();
 }
+
+#endif
 
 } // dit


### PR DESCRIPTION
Make targeting EGL and Vulkan CMake build options (pass -DEGL=ON/OFF or -DVULKAN=ON/OFF on CMake command line to choose). Don't build CMake targets on Emscripten that are currently not useful.