### PR TITLE
include_emscripten

### DIFF
--- a/framework/platform/emscripten/tcuEmscriptenPlatform.cpp
+++ b/framework/platform/emscripten/tcuEmscriptenPlatform.cpp
@@ -29,7 +29,7 @@
 #include "eglwEnums.hpp"
 #include "deMemory.h"
 
-#include "emscripten.h"
+#include <emscripten.h>
 
 tcu::Platform* createPlatform (void)
 {

--- a/framework/platform/tcuMain.cpp
+++ b/framework/platform/tcuMain.cpp
@@ -32,7 +32,7 @@
 #include <cstdio>
 
 #if __EMSCRIPTEN__
-#	include "emscripten.h"
+#	include <emscripten.h>
 
 void requestAnimationFrameCallback(void* arg) {
 	tcu::App* app = reinterpret_cast<tcu::App*>(arg);


### PR DESCRIPTION
Including emscripten.h is a system header, so use <emscripten.h> instead of "emscripten.h"